### PR TITLE
Add status_code to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Each check needs those fields:
 | description | string | A small description for the check| No |  Ensure .git repository is not accessible from the webroot |
 | remediation | string | Give a remediation for this specific "issue" | No | Do not deploy .git folder on production servers |
 | severity | Enum("High", "Medium", "Low", "Informational") | Rate the criticity if it triggers in your environment| No | High |
+| status_code | integer | The HTTP status code that should be returned |
 | headers | List of string | List of headers there should be in the HTTP response | Yes | N/A |
 | match | List of string| List the strings there should be in the HTTP response  | Yes |  "[branch" |
 | no_match | List of string | List the strings there should NOT be in the HTTP response | Yes | N/A |


### PR DESCRIPTION
The default `chopchop.yml` uses `status_code` in some of it's checks, but it's not documented in the README as a possible option.

Had to go looking through the source to see if it was possible to do a "is not 200" rather than a "must be 200".
