### PR TITLE
Added Github Actions workflow to build ChopChop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+on: push
+name: Build ChopChop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install gox
+      run: go get github.com/mitchellh/gox
+    - name: Build using gox
+      run: gox -ldflags "-X main.Version=$BUILD_VERSION -X main.BuildDate=$BUILD_DATE" -output "dist/ChopChop_{{.OS}}_{{.Arch}}"
+    - name: Release
+      uses: fnkr/github-action-ghr@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GHR_COMPRESS: xz
+        GHR_PATH: dist/
+        GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
First initial commit to provide automatic build every time new code hits master. 
It will automatically deploy binaries every time we will do a release. 