### PR TITLE
Fix false positive on Git exposed rule

### DIFF
--- a/chopchop.yml
+++ b/chopchop.yml
@@ -119,6 +119,7 @@ plugins:
   - uri: "/.git/config"
     checks:
       - name: Git exposed
+        status_code: 200
         match:
           - "["
         remediation: Do not deploy .git folder on production servers

--- a/chopchop.yml
+++ b/chopchop.yml
@@ -122,6 +122,9 @@ plugins:
         status_code: 200
         match:
           - "[branch"
+          - "[remote"
+          - "[core]"
+          - "[user]"
         remediation: Do not deploy .git folder on production servers
         description: Verifies that the GIT repository is accessible from the site
         severity: "High"

--- a/chopchop.yml
+++ b/chopchop.yml
@@ -121,7 +121,7 @@ plugins:
       - name: Git exposed
         status_code: 200
         match:
-          - "["
+          - "[branch"
         remediation: Do not deploy .git folder on production servers
         description: Verifies that the GIT repository is accessible from the site
         severity: "High"


### PR DESCRIPTION
We must check that status code is 200 otherwise we could get false positive response for this rule :
```
  - uri: "/.git/config"
    checks:
      - name: Git exposed
        match:
          - "["
        remediation: Do not deploy .git folder on production servers
        description: Verifies that the GIT repository is accessible from the site
        severity: "High"
```

For example this URL https://kinsta.com/.git/config returns a 404 status code and also contains "[" chars, so ChopChop throw a false positive vulnerability 😢 