### PR TITLE
Adding 4 rules for possible Trickbot Trojan Payload hosting

### DIFF
--- a/chopchop.yml
+++ b/chopchop.yml
@@ -375,15 +375,29 @@ plugins:
         severity: "Low"
   - uri: "/images/imgpaper.png"
     checks:
-      - name : Trickbot Trojan Payload imgpaper.png
+      - name : Possible Trickbot Trojan Payload hosting imgpaper.png
         remediation: Make sure your system is'nt compromised
         description: Possible Trickbot Trojan Payload hosting in /images/imgpaper.png
         status_code: 200
         severity: "High"
   - uri: "/images/cursor.png"
     checks:
-      - name : Trickbot Trojan Payload cursor.png
+      - name : Possible Trickbot Trojan Payload hosting cursor.png
         remediation: Make sure your system is'nt compromised
         description: Possible Trickbot Trojan Payload hosting in /images/cursor.png
+        status_code: 200
+        severity: "High"
+  - uri: "/images/redcar.png"
+    checks:
+      - name : Possible Trickbot Trojan Payload hosting redcar.png
+        remediation: Make sure your system is'nt compromised
+        description: Possible Trickbot Trojan Payload hosting in /images/redcar.png
+        status_code: 200
+        severity: "High"
+  - uri: "/ico/VidT6cErs"
+    checks:
+      - name : Possible Trickbot Trojan Payload hosting VidT6cErs
+        remediation: Make sure your system is'nt compromised
+        description: Possible Trickbot Trojan Payload hosting in /ico/VidT6cErs
         status_code: 200
         severity: "High"

--- a/chopchop.yml
+++ b/chopchop.yml
@@ -373,3 +373,17 @@ plugins:
         remediation: Make sure that F5 BIG-IP - TMUI access is monitored
         description: Verifies that under /tmui a F5 BIG-IP TMUI is not accessible
         severity: "Low"
+  - uri: "/images/imgpaper.png"
+    checks:
+      - name : Trickbot Trojan Payload imgpaper.png
+        remediation: Make sure your system is'nt compromised
+        description: Possible Trickbot Trojan Payload hosting in /images/imgpaper.png
+        status_code: 200
+        severity: "High"
+  - uri: "/images/cursor.png"
+    checks:
+      - name : Trickbot Trojan Payload cursor.png
+        remediation: Make sure your system is'nt compromised
+        description: Possible Trickbot Trojan Payload hosting in /images/cursor.png
+        status_code: 200
+        severity: "High"


### PR DESCRIPTION
Adding 4 rules for possible Trickbot Trojan Payload hosting

Sources : https://unit42.paloaltonetworks.com/goodbye-mworm-hello-nworm-trickbot-updates-propagation-module/
https://twitter.com/VK_Intel/status/1281570630169759745
https://urlhaus.abuse.ch/browse.php?search=%2Fimages%2Fimgpaper.png
https://urlhaus.abuse.ch/browse.php?search=%2Fimages%2Fcursor.png
https://urlhaus.abuse.ch/browse.php?search=%2Fimages%2Fredcar.png
https://urlhaus.abuse.ch/browse.php?search=%2Fico%2FVidT6cErs