### PR TITLE
Simplify Docker usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ FROM alpine:3.8
 RUN mkdir -p /tmp
 COPY --from=build /app/gochopchop /tmp/gochopchop
 COPY --from=build /app/chopchop.yml /tmp/chopchop.yml
-CMD ["/tmp/gochopchop"]
+WORKDIR /tmp
+ENTRYPOINT ["/tmp/gochopchop"]

--- a/README.md
+++ b/README.md
@@ -40,12 +40,30 @@ $ go build .
 
 There should be a resulting `gochopchop` binary in the folder.
 
+### Using Docker
+
+```bash
+docker build -t gochopchop .
+```
+
 ## Usage
 
 We are continuously trying to make `goChopChop` as easy as possible. Scanning a host with this utility is as simple as : 
 
 ```bash
 $ ./gochopchop scan --url https://foobar.com
+```
+
+### Using Docker
+
+```bash
+docker run chopchop scan --url https://foobar.com
+```
+
+#### Custom configuration file
+
+```bash
+docker run -v ./:/app chopchop scan -c /app/chopchop.yml --url https://foobar.com
 ```
 
 ## What's next


### PR DESCRIPTION
Make Docker image easier to run: `docker run chopchop scan --url https://foobar.com`

Replace `CMD` instruction by `ENTRYPOINT` in `Dockerfile` to run gochopchop binary by default and append command-line arguments