### PR TITLE
Ability to disable following HTTP redirects for each plugin

### DIFF
--- a/app/scan.go
+++ b/app/scan.go
@@ -87,7 +87,15 @@ func Scan(cmd *cobra.Command, args []string) {
 			if plugin.QueryString != "" {
 				tmpURL += "?" + plugin.QueryString
 			}
-			httpResponse, err := pkg.HTTPGet(insecure, tmpURL)
+
+			// By default we follow HTTP redirects
+			followRedirects := true
+			// But for each plugin we can override and don't follow HTTP redirects
+			if plugin.FollowRedirects != nil && *plugin.FollowRedirects == false {
+				followRedirects = false
+			}
+
+			httpResponse, err := pkg.HTTPGet(insecure, tmpURL, followRedirects)
 			if err != nil {
 				_ = errors.Wrap(err, "Timeout of HTTP Request")
 			}

--- a/data/format_output.go
+++ b/data/format_output.go
@@ -42,9 +42,10 @@ type Check struct {
 type Config struct {
 	Insecure bool `yaml:"insecure"`
 	Plugins  []struct {
-		URI         string  `yaml:"uri"`
-		QueryString string  `yaml:"query_string"`
-		Checks      []Check `yaml:"checks"`
+		URI             string  `yaml:"uri"`
+		QueryString     string  `yaml:"query_string"`
+		Checks          []Check `yaml:"checks"`
+		FollowRedirects *bool   `yaml:"follow_redirects"`
 	} `yaml:"plugins"`
 }
 

--- a/pkg/http.go
+++ b/pkg/http.go
@@ -8,7 +8,7 @@ import (
 )
 
 //HTTPGet return http response of http get request
-func HTTPGet(insecure bool, url string) (*http.Response, error) {
+func HTTPGet(insecure bool, url string, followRedirects bool) (*http.Response, error) {
 	tr := &http.Transport{}
 	if insecure {
 		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
@@ -17,6 +17,15 @@ func HTTPGet(insecure bool, url string) (*http.Response, error) {
 		Transport: tr,
 		Timeout:   time.Second * 3,
 	}
+
+	// If we don't want to follow HTTP redirects
+	if followRedirects == false {
+		// We tell the HTTP Client to don't follow them
+		netClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
 	resp, err := netClient.Get(url)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
Bonjour Clermont-Ferrand 👍 

In some cases (a lot?) we need to disable following HTTP redirects on some plugins.

Which case for example?
If you need to check that there is no "/dashboard" url or to check that this url is secure, yet you do :
```
- uri: "/dashboard"
  checks:
  - name: "Too bad this entry point!"
    remediation: "Secure it or delete it"
    description: "Check a dashboard entry point"
    severity: "High"
    status_code: 200
```

**But if you have a secure application** the "/dashboard" will redirect to a "/login" url (for example), it's great but yet ChopChop will have a HTTP status code of 200 because the "/login" exists! So the check is "biased" 😢 

So I have made a PR to add the ability to disable following HTTP redirects for each plugin :
```
- uri: "/dashboard"
  checks:
  - name: "Too bad this entry point!"
    remediation: "Secure it or delete it"
    description: "Check a dashboard entry point"
    severity: "High"
    status_code: 200
  follow_redirects: false
```

🌞  Have a nice day!