### PR TITLE
Fixing ChopChop when we are not specifying a `url` or a `url-file`.

### DIFF
--- a/app/scan.go
+++ b/app/scan.go
@@ -47,6 +47,10 @@ func Scan(cmd *cobra.Command, args []string) {
 	var tmpURL string
 	var urlList []string
 
+	if url == "" && urlFile == "" {
+		log.Fatal("`url` or either `url-file` have been specified! Use `scan -help` for usage")
+	}
+
 	cfg, err := os.Open(configFile)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Closes: #44