### PR TITLE
Added the ability to specify the 'non-presence' of HTTP headers.

### DIFF
--- a/data/format_output.go
+++ b/data/format_output.go
@@ -36,6 +36,7 @@ type Check struct {
 	Description *string       `yaml:"description"`
 	NoMatch     []*string     `yaml:"no_match"`
 	Headers     []*string     `yaml:"headers"`
+	NoHeaders   []*string     `yaml:"no_headers"`
 }
 
 // Config struct to load the configuration from the YAML file

--- a/pkg/resp_analysis.go
+++ b/pkg/resp_analysis.go
@@ -63,9 +63,8 @@ func ResponseAnalysis(resp *http.Response, signature data.Check) bool {
 			if v, kFound := resp.Header[pHeaders[0]]; kFound {
 				// Key found - check value
 				vFound := false
-				for i, n := range v {
+				for _, n := range v {
 					if strings.Contains(n, pHeaders[1]) {
-						_ = i
 						vFound = true
 					}
 				}
@@ -74,6 +73,25 @@ func ResponseAnalysis(resp *http.Response, signature data.Check) bool {
 				}
 			} else {
 				return false
+			}
+		}
+	}
+
+	if signature.NoHeaders != nil {
+		for i := 0; i < len(signature.NoHeaders); i++ {
+			// Parse NoHeaders
+			pNoHeaders := strings.Split(*signature.NoHeaders[i], ":")
+			v, kFound := resp.Header[pNoHeaders[0]]
+
+			// if the header has not been found, hit!
+			if !kFound {
+				return true
+			} else {
+				for _, n := range v { // usually, only one iteration
+					if strings.Contains(n, pNoHeaders[1]) {
+						return false
+					}
+				}
 			}
 		}
 	}

--- a/pkg/resp_analysis.go
+++ b/pkg/resp_analysis.go
@@ -86,6 +86,8 @@ func ResponseAnalysis(resp *http.Response, signature data.Check) bool {
 			// if the header has not been found, hit!
 			if !kFound {
 				return true
+			} else if kFound && len(pNoHeaders) == 1 { // if the header has not been specified.
+				return false
 			} else {
 				for _, n := range v { // usually, only one iteration
 					if strings.Contains(n, pNoHeaders[1]) {


### PR DESCRIPTION
You can specify them using a configuration file like this: 


```yaml
---
insecure: false
plugins:
  - uri: "/foobar"
    checks:
      - name: strict transport security detection
        remediation: No Strict transport security has been declared, add one!
        description: Triggers if Strict Transport Policy has not been properly declared
        severity: "Low"
        no_headers:
          - "Strict-Transport-Security:max-age=500; includeSubDomains; preload"
```

Closes #7